### PR TITLE
Swapped yaml-js with js-yaml since it handles nested keys in yaml files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "deepmerge": "^1.5.1",
     "glob": "^7.1.2",
     "js-yaml": "^3.11.0",
-    "virtual-module-webpack-plugin": "^0.3.0"
+    "virtual-module-webpack-plugin": "^0.4.0"
   },
   "devDependencies": {
     "eslint": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "dependencies": {
     "deepmerge": "^1.5.1",
     "glob": "^7.1.2",
-    "virtual-module-webpack-plugin": "^0.3.0",
-    "yaml-js": "^0.2.0"
+    "js-yaml": "^3.11.0",
+    "virtual-module-webpack-plugin": "^0.3.0"
   },
   "devDependencies": {
     "eslint": "^4.5.0"

--- a/src/webpack-rails-i18n-loader.js
+++ b/src/webpack-rails-i18n-loader.js
@@ -1,7 +1,7 @@
 const fs        = require("fs")
 const glob      = require("glob")
 const path      = require("path")
-const yaml      = require("yaml-js")
+const yaml      = require("js-yaml")
 const deepmerge = require("deepmerge")
 
 const listLocaleFiles = ({ localesPath, pattern }) => glob.sync(pattern, { cwd: localesPath })

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,6 +465,13 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-yaml@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.9.1:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
@@ -804,7 +811,3 @@ write@^0.2.1:
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-
-yaml-js@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/yaml-js/-/yaml-js-0.2.0.tgz#30cdcc7bf678fdd00695ec34eb17b13aa8961632"


### PR DESCRIPTION
yaml-js saw 
 ```
 main: 
    repo: 'hello' 
```
and 
```
other: 
  repo: 'hello again' 
```
as duplicate keys on repo, and it would not generate the json file.